### PR TITLE
Correct installation steps in docs

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -16,20 +16,38 @@ Eventually, we will have a ``conda`` package, but for now you need to create a n
 
 1. Create a new conda environment::
 
-    conda env create -f https://raw.githubusercontent.com/dominiquesydow/dynophores/master/environment.yml -n dynophores
+    conda env create -f https://raw.githubusercontent.com/dominiquesydow/dynophores/master/devtools/conda-envs/test_env.yaml -n dynophores
 
-2. Activate the new environment::
+   Installing via ``conda`` often takes a while. Instead you can also use ``mamba``, a faster reimplementation of the conda package manager in C++.
+   Find ``mamba`` installation instructions `here <https://mamba.readthedocs.io/en/latest/getting_started.html#for-new-users>`_.
+   If you have ``mamba`` installed successfully, create your conda environment within a couple of seconds::
+
+    mamba env create -f https://raw.githubusercontent.com/dominiquesydow/dynophores/master/devtools/conda-envs/test_env.yaml -n dynophores
+
+2. Activate the new environment and install a few Jupyter extensions we will need for our dynophore notebook::
 
     conda activate dynophores
+    jupyter labextension install @jupyter-widgets/jupyterlab-manager nglview-js-widgets @jupyterlab/toc
 
-3. Run ``dynoviz -h`` to test that it works.
 
-4. Run ``dynoviz create --dyno path/to/dyno/folder --pdb path/to/pdb/file --dcd path/to/dcd/file 
---workspace path/to/workspace/folder`` to explore your dynophore data in a new notebook.
+   Note: We do not have a ``dynophores`` conda package yet. Until we do, you will need to perform the additional steps 
+   described below under "Install from the latest development snapshot" before you can continue.
 
-5. Run ``dynoviz open path/to/your/dyno/notebook`` if you already have set up your dynophore 
-notebook (i.e. if you want to revisit a notebook created in step 4). 
-Note: This command is equivalent to ``jupyter lab path/to/your/dyno/notebook``.
+3. Test that your installation works::
+
+    dynoviz -h
+
+4. Explore your dynophore data in a new notebook::
+
+    dynoviz create --dyno path/to/dyno/folder --pdb path/to/pdb/file --dcd path/to/dcd/file --workspace path/to/workspace/folder
+
+5. If you already have set up your dynophore notebook (i.e. if you want to revisit a notebook created in step 4), run::
+
+    dynoviz open path/to/your/dyno/notebook
+
+   Note: This command is equivalent to::
+    
+    jupyter lab path/to/your/dyno/notebook
 
 Install from the latest development snapshot
 --------------------------------------------
@@ -58,7 +76,7 @@ the next step is downloading a copy of the current state of the
     mkdir -p ~/Documents
     unzip dynophores.zip -d ~/Documents
     cd ~/Documents
-    pip install dynophores
+    pip install dynophores-master/
     dynoviz -h
 
 .. raw:: html
@@ -78,7 +96,7 @@ the next step is downloading a copy of the current state of the
     mkdir ~/Documents/
     Expand-Archive dynophores.zip -d ~/Documents
     cd ~/Documents
-    pip install dynophores
+    pip install dynophores-master/
     dynoviz -h
 
 .. raw:: html


### PR DESCRIPTION
## Description

Correct installation instruction in `docs/installing.rst`

## Todos

  - [x] Update environment file!
  - [x] Add comment about `mamba`
  - [x] Add Jupyter extensions!
  - [x] Add comment to "Install from the conda package" that at step 2 we currently need more steps (until the `conda` package is ready)
  - [x] `pip install dynophores` > `pip install dynophores-master`

## Questions

None

## Status
- [x] Ready to go