### PR TITLE
Add user notebook to package (not only docs)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -68,6 +68,7 @@ jobs:
       run: |
         PYTEST_ARGS="--nbval-lax --current-env --nbval-cell-timeout=900"
         pytest $PYTEST_ARGS docs/tutorials/*.ipynb -vvv
+        pytest $PYTEST_ARGS dynophores/notebooks/*.ipynb -vvv
 
     - name: CodeCov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -124,11 +124,13 @@ jobs:
         if: always()
         run: |
           black-nb --check -l 99 docs/tutorials/*.ipynb
+          black-nb --check -l 99 dynophores/notebooks/*.ipynb
 
       - name: Run flake8-nb
         shell: bash -l {0}
         run: |
           flake8-nb --config setup.cfg docs/tutorials/*.ipynb
+          flake8-nb --config setup.cfg dynophores/notebooks/*.ipynb
 
 
   docs:

--- a/dynophores/cli.py
+++ b/dynophores/cli.py
@@ -126,7 +126,7 @@ def _copy_notebook(workspace_path, dyno_path, pdb_path, dcd_path):
         raise RuntimeError(f"Input file does not exist: `{dcd_path.absolute()}`")
 
     # Set template notebook and user notebook filepath
-    notebook_path = Path(_version.__file__).parent / "../docs/tutorials/dynophore.ipynb"
+    notebook_path = Path(_version.__file__).parent / "notebook/dynophore.ipynb"
     new_notebook_path = Path(workspace_path) / "dynophore.ipynb"
 
     # Copy template notebook to user-defined workspace
@@ -148,9 +148,9 @@ def _copy_notebook(workspace_path, dyno_path, pdb_path, dcd_path):
     # Replace template filepaths in notebook with user-defined filepaths
     print("\nUpdate filepaths in notebook to user filepaths...")
     search_replace_tuples = [
-        ("../../dynophores/tests/data/1KE7-1/DynophoreApp", str(dyno_path.absolute())),
-        ("../../dynophores/tests/data/1KE7-1/startframe.pdb", str(pdb_path.absolute())),
-        ("../../dynophores/tests/data/1KE7-1/trajectory.dcd", str(dcd_path.absolute())),
+        ("../tests/data/1KE7-1/DynophoreApp", str(dyno_path.absolute())),
+        ("../tests/data/1KE7-1/startframe.pdb", str(pdb_path.absolute())),
+        ("../tests/data/1KE7-1/trajectory.dcd", str(dcd_path.absolute())),
     ]
     _update_paths_in_notebook(new_notebook_path, search_replace_tuples)
 

--- a/dynophores/notebooks/dynophore.ipynb
+++ b/dynophores/notebooks/dynophore.ipynb
@@ -1,0 +1,347 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dynophore notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "15fdc47921214516b2fcf026771002ae",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": []
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from dynophores import Dynophore\n",
+    "from dynophores import plot, view3d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dyno_path = Path(\"../tests/data/1KE7-1/DynophoreApp\")\n",
+    "pdb_path = Path(\"../tests/data/1KE7-1/startframe.pdb\")\n",
+    "dcd_path = Path(\"../tests/data/1KE7-1/trajectory.dcd\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3D view"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ba47fcfa37ab4f86be1c3b5606937650",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "ThemeManager()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9fdf74fec44849c78b646e90f9ab0a93",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "NGLWidget(gui_style='ngl', max_frame=100)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "pml_path = dyno_path / \"dynophore.pml\"\n",
+    "view = view3d.show_dynophore3d(pml_path, pdb_path, dcd_path)\n",
+    "view.display(gui=True, style=\"ngl\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "view.render_image(trim=True, factor=2, transparent=True);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "\n",
+      "text/plain": [
+       "<IPython.core.display.Image object>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "view._display_image()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Statistics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load data as `Dynophore` object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dynophore = Dynophore.from_files(dyno_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot interactions overview (heatmap)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fbfde44727d84021bcaf15f5488d4fcc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(SelectMultiple(description='Superfeature name(s):', index=(0,), options=('all', 'AR[4605…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot.interactive.superfeatures_vs_envpartners(dynophore);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot superfeature occurrences (time series)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "86bc2e7b952d42028202aa222c5a5637",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(SelectMultiple(description='Superfeature name(s):', index=(0,), options=('all', 'AR[4605…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot.interactive.superfeatures_occurrences(dynophore);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot interactions for example superfeature (time series)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Interaction occurrence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "90207ad246024d71ba782e49c86798cb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(SelectMultiple(description='Superfeature name(s):', index=(0,), options=('AR[4605,4607,4…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot.interactive.envpartners_occurrences(dynophore);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Interaction distances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e89374f472f849eaa3ba8db5dd1a180c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(SelectMultiple(description='Superfeature name(s):', index=(0,), options=('AR[4605,4607,4…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot.interactive.envpartners_distances(dynophore);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Interaction profile (all-in-one)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "46a254e94b4e45cd98bb2378665a7b45",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "interactive(children=(Select(description='Superfeature name(s):', options=('AR[4605,4607,4603,4606,4604]', 'AR…"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot.interactive.envpartners_all_in_one(dynophore);"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Description

Problem: When user notebook lives only in `docs/tutorials` it will not be shipped with the package upon `pip`/`conda` installation (as far as I understand). Thus add a copy of the `docs/tutorials/dynophore.ipynb` to new folder `dynophores/notebooks`. 

## Todos

  - [x] Add user notebook to package dir!
  - [x] Add this notebook to CI

## Questions

None

## Status

- [ ] Ready to go